### PR TITLE
Add raw functions to use repeated message

### DIFF
--- a/internal/gen/wrappers.go
+++ b/internal/gen/wrappers.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
-	"github.com/thechriswalker/protoc-gen-twirp_js/internal/gen/stringutils"
+	"github.com/juntaki/protoc-gen-twirp_js/internal/gen/stringutils"
 )
 
 // Each type we import as a protocol buffer (other than FileDescriptorProto) needs

--- a/internal/gen/wrappers.go
+++ b/internal/gen/wrappers.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
-	"github.com/juntaki/protoc-gen-twirp_js/internal/gen/stringutils"
+	"github.com/thechriswalker/protoc-gen-twirp_js/internal/gen/stringutils"
 )
 
 // Each type we import as a protocol buffer (other than FileDescriptorProto) needs

--- a/main.go
+++ b/main.go
@@ -12,9 +12,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
-	"github.com/juntaki/protoc-gen-twirp_js/internal/gen"
-	"github.com/juntaki/protoc-gen-twirp_js/internal/gen/stringutils"
-	"github.com/juntaki/protoc-gen-twirp_js/internal/gen/typemap"
+	"github.com/thechriswalker/protoc-gen-twirp_js/internal/gen"
+	"github.com/thechriswalker/protoc-gen-twirp_js/internal/gen/stringutils"
+	"github.com/thechriswalker/protoc-gen-twirp_js/internal/gen/typemap"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -88,33 +88,6 @@ func (g *generator) generateProtobufClient(file *descriptor.FileDescriptorProto,
 	g.P(`    return {`)
 	// for each method...
 	l := len(service.Method)
-	for _, method := range service.Method {
-		methName := methodName(method)
-		jsMethodName := strings.ToLower(methName[0:1]) + methName[1:]
-		inputName, outputName := methodTypesNames(method)
-		// we need field definitions for each field
-		// then we don't have to rely on
-
-		comments, err := g.reg.MethodComments(file, service, method)
-		if err == nil && comments.Leading != "" {
-			g.P(`        /**`)
-			g.printComments(comments, `         * `)
-			g.P(`         */`)
-		}
-		g.P(
-			`        `,
-			jsMethodName,
-			`: function(data) { return rpc(`,
-			strconv.Quote(methName),
-			`, rpc.buildMessage(pb.`,
-			inputName,
-			`, data), pb.`,
-			outputName,
-			`); },`,
-		)
-	}
-
-	// to use raw parameter
 	for i, method := range service.Method {
 		methName := methodName(method)
 		jsMethodName := strings.ToLower(methName[0:1]) + methName[1:]
@@ -135,7 +108,7 @@ func (g *generator) generateProtobufClient(file *descriptor.FileDescriptorProto,
 		g.P(
 			`        `,
 			jsMethodName,
-			`Raw: function(data) { return rpc(`,
+			`: function(data) { return rpc(`,
 			strconv.Quote(methName),
 			`, data, pb.`,
 			outputName,


### PR DESCRIPTION
buildMessage() is easy to use, but insufficient for repeated message (or maybe other type of nested message) like the following.
https://github.com/juntaki/firestarter/blob/master/proto/config.proto#L49

I had tried to modify buildMessage(), but I thounght adding raw function is simpler and better idea. what do you think of it?