### PR TITLE
docs: fix typo and quoting problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/protoc-gen-twirp_js

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Creates javascript bindings compatible with both the browser and node.js as
 common-js modules. This means that you should run your `protoc` with options
-`--js_out="import_style=commonjs;binary:<output path>" --twirp_out="<output path>"`
+`--js_out="import_style=commonjs,binary:<output path>" --twirp_out="<output path>"`
 
 The resulting javascript files `<service>_pb.js` and `<service>_pb_twirp.js` will
 be compatible with all commonjs aware module systems, for example, nodejs, browserify,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Creates javascript bindings compatible with both the browser and node.js as
 common-js modules. This means that you should run your `protoc` with options
-for the `--js-out` as `--js-out=import_style=commonjs;binary:<path>`.
+`--js_out="import_style=commonjs;binary:<output path>" --twirp_out="<output path>"`
 
 The resulting javascript files `<service>_pb.js` and `<service>_pb_twirp.js` will
 be compatible with all commonjs aware module systems, for example, nodejs, browserify,


### PR DESCRIPTION
The semicolon terminated my command, resulting in confusing output:
```
Missing input file.
/bin/sh: binary:.: command not found
```

I added the `--twirp_out` parameter. I'm brand new to twirp so I'm not certain when it's needed, but I would guess "all the time".